### PR TITLE
Add --scale parameter to set the window scaling.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,17 +107,15 @@ pub fn main() -> Result<(), pico_args::Error> {
     // large enough for any agon video mode
     let mut vgabuf: Vec<u8> = Vec::with_capacity(1024*768*3);
     unsafe { vgabuf.set_len(1024*768*3); }
+    let scale = args.scale.unwrap_or(2);
     let mut mode_w = 640;
     let mut mode_h = 480;
     let mut audio_buf: Vec<u8> = Vec::with_capacity(AUDIO_BUFLEN);
     unsafe { audio_buf.set_len(AUDIO_BUFLEN); }
 
-    // doesn't seem to work...
-    sdl2::hint::set("SDL_HINT_RENDER_SCALE_QUALITY", "2");
-
     'running: loop {
 
-        let mut window = video_subsystem.window("Fab Agon Emulator", 1024, 768)
+        let mut window = video_subsystem.window("Fab Agon Emulator", mode_w * scale, mode_h * scale)
             .resizable()
             .position_centered()
             .build()

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -9,6 +9,7 @@ OPTIONS:
   -f, --fullscreen      Start in fullscreen mode
   -h, --help            Prints help information
   -u, --unlimited-cpu   Don't limit eZ80 CPU frequency
+  --scale               Set window scaling factor (default is 2)
   --firmware 1.03       Use 1.03 firmware (default is 1.04)
   --sdcard PATH         Sets the path of the emulated SDCard
 
@@ -30,6 +31,7 @@ pub struct AppArgs {
     pub debugger: bool,
     pub unlimited_cpu: bool,
     pub fullscreen: bool,
+    pub scale: Option<u32>,
     pub mos_bin: Option<std::path::PathBuf>,
     pub vdp_dll: Option<std::path::PathBuf>,
     pub firmware: FirmwareVer,
@@ -50,6 +52,7 @@ pub fn parse_args() -> Result<AppArgs, pico_args::Error> {
         debugger: pargs.contains(["-d", "--debugger"]),
         unlimited_cpu: pargs.contains(["-u", "--unlimited_cpu"]),
         fullscreen: pargs.contains(["-f", "--fullscreen"]),
+        scale: pargs.opt_value_from_str("--scale")?,
         mos_bin: pargs.opt_value_from_str("--mos")?,
         vdp_dll: pargs.opt_value_from_str("--vdp")?,
         firmware: if let Some(ver) = firmware_ver {


### PR DESCRIPTION
This adds the --scale parameter from the old emulator. It defaults to 2x the windowsize of the intial mode (640x480).