### PR TITLE
Issue #6: Fix build on mac clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+fab-agon-emulator
 src/vdp/*.o
 src/vdp/*.so
 .DS_Store

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo:rustc-link-search=native=/opt/homebrew/lib");
     if std::env::var("FORCE").is_err() {
         eprintln!("Don't invoke `cargo build` directly. Try using 'make' to build fab-agon-emulator.");
         eprintln!("If you really know what you're doing, try again with `FORCE=1 cargo build`");

--- a/src/vdp/vdp-console8/graphics.h
+++ b/src/vdp/vdp-console8/graphics.h
@@ -28,14 +28,14 @@ uint8_t			palette[64];					// Storage for the palette
 //
 void sendModeInformation() {
 	byte packet[] = {
-		canvasW & 0xFF,						// Width in pixels (L)
-		(canvasW >> 8) & 0xFF,				// Width in pixels (H)
-		canvasH & 0xFF,						// Height in pixels (L)
-		(canvasH >> 8) & 0xFF,				// Height in pixels (H)
-		canvasW / fontW,					// Width in characters (byte)
-		canvasH / fontH,					// Height in characters (byte)
-		getVGAColourDepth(),				// Colour depth
-		videoMode,							// The video mode number
+		static_cast<byte>(canvasW & 0xFF),						// Width in pixels (L)
+		static_cast<byte>((canvasW >> 8) & 0xFF),				// Width in pixels (H)
+		static_cast<byte>(canvasH & 0xFF),						// Height in pixels (L)
+		static_cast<byte>((canvasH >> 8) & 0xFF),				// Height in pixels (H)
+		static_cast<byte>(canvasW / fontW),					// Width in characters (byte)
+		static_cast<byte>(canvasH / fontH),					// Height in characters (byte)
+		static_cast<byte>(getVGAColourDepth()),				// Colour depth
+		static_cast<byte>(videoMode),							// The video mode number
 	};
 	send_packet(PACKET_MODE, sizeof packet, packet);
 }

--- a/src/vdp/vdp-console8/vdu_audio.h
+++ b/src/vdp/vdp-console8/vdu_audio.h
@@ -78,8 +78,8 @@ void init_audio() {
 //
 void sendAudioStatus(int channel, int status) {
 	byte packet[] = {
-		channel,
-		status,
+		static_cast<byte>(channel),
+		static_cast<byte>(status),
 	};
 	send_packet(PACKET_AUDIO, sizeof packet, packet);
 }

--- a/src/vdp/vdp-console8/vdu_sys.h
+++ b/src/vdp/vdp-console8/vdu_sys.h
@@ -41,8 +41,8 @@ void vdu_sys_video_kblayout() {
 //
 void sendCursorPosition() {
 	byte packet[] = {
-		textCursor.X / fontW,
-		textCursor.Y / fontH,
+		static_cast<byte>(textCursor.X / fontW),
+		static_cast<byte>(textCursor.Y / fontH),
 	};
 	send_packet(PACKET_CURSOR, sizeof packet, packet);	
 }
@@ -54,7 +54,7 @@ void sendScreenChar(int x, int y) {
 	int py = y * fontH;
 	char c = getScreenChar(px, py);
 	byte packet[] = {
-		c,
+		static_cast<byte>(c),
 	};
 	send_packet(PACKET_SCRCHAR, sizeof packet, packet);
 }
@@ -77,14 +77,15 @@ void sendScreenPixel(int x, int y) {
 //
 void sendTime() {
 	byte packet[] = {
-		rtc.getYear() - EPOCH_YEAR,			// 0 - 255
-		rtc.getMonth(),						// 0 - 11
-		rtc.getDay(),						// 1 - 31
-		rtc.getDayofYear(),					// 0 - 365
-		rtc.getDayofWeek(),					// 0 - 6
-		rtc.getHour(true),					// 0 - 23
-		rtc.getMinute(),					// 0 - 59
-		rtc.getSecond(),					// 0 - 59
+		static_cast<byte>(rtc.getYear() - EPOCH_YEAR),			// 0 - 255
+		static_cast<byte>(rtc.getMonth()),				// 0 - 11
+		static_cast<byte>(rtc.getDay()),				// 1 - 31
+		static_cast<byte>(rtc.getDayofYear()&0xff),				// 0 - 365
+		static_cast<byte>(rtc.getDayofYear()>>8),				// 0 - 365
+		static_cast<byte>(rtc.getDayofWeek()),				// 0 - 6
+		static_cast<byte>(rtc.getHour(true)),				// 0 - 23
+		static_cast<byte>(rtc.getMinute()),				// 0 - 59
+		static_cast<byte>(rtc.getSecond()),				// 0 - 59
 	};
 	send_packet(PACKET_RTC, sizeof packet, packet);
 }
@@ -121,11 +122,11 @@ void sendKeyboardState() {
 	byte ledState;
 	getKeyboardState(&delay, &rate, &ledState);
 	byte packet[] = {
-		delay & 0xFF,
-		(delay >> 8) & 0xFF,
-		rate & 0xFF,
-		(rate >> 8) & 0xFF,
-		ledState
+		static_cast<byte>(delay & 0xFF),
+		static_cast<byte>((delay >> 8) & 0xFF),
+		static_cast<byte>(rate & 0xFF),
+		static_cast<byte>((rate >> 8) & 0xFF),
+		static_cast<byte>(ledState)
 	};
 	send_packet(PACKET_KEYSTATE, sizeof packet, packet);
 }

--- a/src/vdp/vdp-quark103/video.ino
+++ b/src/vdp/vdp-quark103/video.ino
@@ -311,8 +311,8 @@ void wait_eZ80() {
 //
 void sendCursorPosition() {
 	byte packet[] = {
-		charX / Canvas->getFontInfo()->width,
-		charY / Canvas->getFontInfo()->height,
+		static_cast<byte>(charX / Canvas->getFontInfo()->width),
+		static_cast<byte>(charY / Canvas->getFontInfo()->height),
 	};
 	send_packet(PACKET_CURSOR, sizeof packet, packet);	
 }
@@ -324,7 +324,7 @@ void sendScreenChar(int x, int y) {
 	int py = y * Canvas->getFontInfo()->height;
 	char c = get_screen_char(px, py);
 	byte packet[] = {
-		c,
+		static_cast<byte>(c),
 	};
 	send_packet(PACKET_SCRCHAR, sizeof packet, packet);
 }
@@ -348,10 +348,10 @@ void sendScreenPixel(int x, int y) {
 		}
 	}	
 	byte packet[] = {
-		pixel.R,	// Send the colour components
-		pixel.G,
-		pixel.B,
-		pixelIndex,	// And the pixel index in the palette
+		static_cast<byte>(pixel.R),	// Send the colour components
+		static_cast<byte>(pixel.G),
+		static_cast<byte>(pixel.B),
+		static_cast<byte>(pixelIndex),	// And the pixel index in the palette
 	};
 	send_packet(PACKET_SCRPIXEL, sizeof packet, packet);	
 }
@@ -360,8 +360,8 @@ void sendScreenPixel(int x, int y) {
 //
 void sendPlayNote(int channel, int success) {
 	byte packet[] = {
-		channel,
-		success,
+		static_cast<byte>(channel),
+		static_cast<byte>(success),
 	};
 	send_packet(PACKET_AUDIO, sizeof packet, packet);	
 }
@@ -372,13 +372,13 @@ void sendModeInformation() {
 	int w = Canvas->getWidth();
 	int h = Canvas->getHeight();
 	byte packet[] = {
-		w & 0xFF,	 						// Width in pixels (L)
-		(w >> 8) & 0xFF,					// Width in pixels (H)
-		h & 0xFF,							// Height in pixels (L)
-		(h >> 8) & 0xFF,					// Height in pixels (H)
-		w / Canvas->getFontInfo()->width ,	// Width in characters (byte)
-		h / Canvas->getFontInfo()->height ,	// Height in characters (byte)
-		VGAColourDepth,						// Colour depth
+		static_cast<byte>(w & 0xFF),	 						// Width in pixels (L)
+		static_cast<byte>((w >> 8) & 0xFF),					// Width in pixels (H)
+		static_cast<byte>(h & 0xFF),							// Height in pixels (L)
+		static_cast<byte>((h >> 8) & 0xFF),					// Height in pixels (H)
+		static_cast<byte>(w / Canvas->getFontInfo()->width) ,	// Width in characters (byte)
+		static_cast<byte>(h / Canvas->getFontInfo()->height) ,	// Height in characters (byte)
+		static_cast<byte>(VGAColourDepth),						// Colour depth
 	};
 	send_packet(PACKET_MODE, sizeof packet, packet);
 }
@@ -387,14 +387,15 @@ void sendModeInformation() {
 //
 void sendTime() {
 	byte packet[] = {
-		rtc.getYear() - EPOCH_YEAR,			// 0 - 255
-		rtc.getMonth(),						// 0 - 11
-		rtc.getDay(),						// 1 - 31
-		rtc.getDayofYear(),					// 0 - 365
-		rtc.getDayofWeek(),					// 0 - 6
-		rtc.getHour(true),					// 0 - 23
-		rtc.getMinute(),					// 0 - 59
-		rtc.getSecond(),					// 0 - 59
+		static_cast<byte>(rtc.getYear() - EPOCH_YEAR),			// 0 - 255
+		static_cast<byte>(rtc.getMonth()),						// 0 - 11
+		static_cast<byte>(rtc.getDay()),						// 1 - 31
+		static_cast<byte>(rtc.getDayofYear() & 0xff),					// 0 - 365
+		static_cast<byte>(rtc.getDayofYear() >> 8),					// 0 - 365
+		static_cast<byte>(rtc.getDayofWeek()),					// 0 - 6
+		static_cast<byte>(rtc.getHour(true)),					// 0 - 23
+		static_cast<byte>(rtc.getMinute()),					// 0 - 59
+		static_cast<byte>(rtc.getSecond()),					// 0 - 59
 	};
 	send_packet(PACKET_RTC, sizeof packet, packet);
 }
@@ -407,11 +408,11 @@ void sendKeyboardState() {
 	bool scrollLock;
 	PS2Controller.keyboard()->getLEDs(&numLock, &capsLock, &scrollLock);
 	byte packet[] = {
-		kbRepeatDelay & 0xFF,
-		(kbRepeatDelay >> 8) & 0xFF,
-		kbRepeatRate & 0xFF,
-		(kbRepeatRate >> 8) & 0xFF,
-		scrollLock | (capsLock << 1) | (numLock << 2)
+		static_cast<byte>(kbRepeatDelay & 0xFF),
+		static_cast<byte>((kbRepeatDelay >> 8) & 0xFF),
+		static_cast<byte>(kbRepeatRate & 0xFF),
+		static_cast<byte>((kbRepeatRate >> 8) & 0xFF),
+		static_cast<byte>(scrollLock | (capsLock << 1) | (numLock << 2))
 	};
 	send_packet(PACKET_KEYSTATE, sizeof packet, packet);
 }
@@ -735,7 +736,7 @@ void wait_shiftkey() {
 			byte packet[] = {
 				item.ASCII,
 				0,
-				item.vk,
+				static_cast<byte>(item.vk),
 				item.down,
 			};
 			send_packet(PACKET_KEYCODE, sizeof packet, packet);
@@ -810,7 +811,7 @@ void do_keyboard() {
 		byte packet[] = {
 			keycode,
 			modifiers,
-			item.vk,
+			static_cast<byte>(item.vk),
 			item.down,
 		};
 		send_packet(PACKET_KEYCODE, sizeof packet, packet);

--- a/src/vdp/vdp-quark104/vdu_sys.h
+++ b/src/vdp/vdp-quark104/vdu_sys.h
@@ -195,7 +195,7 @@ void VDUStreamProcessor::sendScreenChar(uint16_t x, uint16_t y) {
 	uint16_t py = y * fontH;
 	char c = getScreenChar(px, py);
 	uint8_t packet[] = {
-		c,
+		static_cast<byte>(c),
 	};
 	send_packet(PACKET_SCRCHAR, sizeof packet, packet);
 }


### PR DESCRIPTION
I saw there was an open issue, so I thought I'd fix it.

BTW, I think I uncloaked an actual bug during this work.  The dayofyear value (used in a few places) could be bigger than a byte, but we're coercing it to byte, so we'd better do the same thing we've done elsewhere and send LSB first.  I have done that and only hope that the other side is also expecting the same set of bytes.  If it isn't there's still another bug needs to be fixed.