### PR TITLE
Fix: Make fails with undefined reference to 'pthread_create' #16

### DIFF
--- a/src/vdp/Makefile
+++ b/src/vdp/Makefile
@@ -15,7 +15,7 @@ userspace-vdp-gl/vdp_gl.a:
 	$(MAKE) -C userspace-vdp-gl/src
 
 test_main: $(OBJS) userspace-vdp-gl/vdp_gl.a vdp_quark104.o test_main.o
-	$(CXX) $(OBJS) -lpthread test_main.o vdp-1.03.o userspace-vdp-gl/src/vdp-gl.a -o test_main
+	$(CXX) $(OBJS) -pthread test_main.o vdp-1.03.o userspace-vdp-gl/src/vdp-gl.a -o test_main
 
 vdp_console8.so: $(OBJS) userspace-vdp-gl/vdp_gl.a vdp-console8.o
 	$(CXX) -shared $(OBJS) vdp-console8.o userspace-vdp-gl/src/vdp-gl.a -o vdp_console8.so


### PR DESCRIPTION
A trivial change to enable this to build on Debian 11 plus possible other distros.