### PR TITLE
Fix build on Windows (mingw)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ src/vdp/*.so
 .DS_Store
 firmware/vdp_*.so
 fab-agon-emulator
+*.exe
+SDL2.dll

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 all: check vdp cargo
 
 check:
+ifeq ($(OS),Windows_NT)
+	@if not exist ./src/vdp/userspace-vdp-gl/README.md ( echo Error: no source tree in ./src/vdp/userspace-vdp. && echo Maybe you forgot to run: git submodule update --init && exit /b 1 )
+else
 	@if [ ! -f ./src/vdp/userspace-vdp-gl/README.md ]; then echo "Error: no source tree in ./src/vdp/userspace-vdp."; echo "Maybe you forgot to run: git submodule update --init"; echo; exit 1; fi
+endif
 
 vdp:
 ifeq ($(PLATFORM),mac)
@@ -13,8 +17,13 @@ endif
 	cp src/vdp/*.so firmware/
 
 cargo:
+ifeq ($(OS),Windows_NT)
+	set FORCE=1 && cargo build -r
+	cp ./target/release/fab-agon-emulator.exe .
+else
 	FORCE=1 cargo build -r
 	cp ./target/release/fab-agon-emulator .
+endif
 
 vdp-clean:
 	$(MAKE) -C src/vdp clean

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Read about other command-line options with:
 * add C:\Program Files (x86)\GnuWin32\bin to path
 * Install mingw64 from https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-16.0.6-11.0.1-ucrt-r2/winlibs-x86_64-mcf-seh-gcc-13.2.0-llvm-16.0.6-mingw-w64ucrt-11.0.1-r2.zip
 * extract to C:\mingw64 and add C:\mingw64\bin to path
+* Install CoreUtils for Windows from https://sourceforge.net/projects/gnuwin32/files/coreutils/5.3.0/coreutils-5.3.0-bin.zip
+* extract to C:\coreutils (or other location of your choice) and add C:\coreutils\bin to path
 * get SDL2 from https://github.com/libsdl-org/SDL/releases/download/release-2.28.3/SDL2-devel-2.28.3-mingw.zip
 * extract to C:\Users\<user>\.rustup\toolchains\stable-x86_64-pc-windows-gnu
 * copy SDL2.dll to the root of the project
 * run `make` in the root of the project
-* manually copy built vdp*.so files from userspace-vdp to the root of the project
-* run `cargo run --release` in the root of the project
+* run `fab-agon-emulator.exe` in the root of the project


### PR DESCRIPTION
Added a few small changes to the main makefile to allow building the emulator directly on Windows using MinGW and GNU Make.

Also added CoreUtils for Windows as build prerequisite; see README.md for instructions how to install it. This package provides Windows versions of some Linux commands like cp, test, and others, which minimizes the need for OS-specific logic in the makefile.