### PR TITLE
PLATFORM=mac massage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ keywords = ["Agon Light", "Agon Console8", "emulator"]
 homepage = "https://github.com/tomm/fab-agon-emulator"
 repository = "https://github.com/tomm/fab-agon-emulator"
 
+[build-dependencies]
+# system-deps does platform searches for dependencies and sets -L and -l appropriately
+system-deps = "2.0"
+
+[package.metadata.system-deps]
+sdl2 = "0.35.2"
+
 [dependencies]
 sdl2 = "0.35.2"
 pico-args = "0.5.0"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 all: check vdp cargo
 
+COMPILER := $(filter g++ clang,$(shell $(CXX) --version))
+
 check:
 	@if [ ! -f ./src/vdp/userspace-vdp-gl/README.md ]; then echo "Error: no source tree in ./src/vdp/userspace-vdp."; echo "Maybe you forgot to run: git submodule update --init"; echo; exit 1; fi
 
 vdp:
-ifeq ($(PLATFORM),mac)
+ifeq ($(COMPILER),clang)
+	# clang is strict about narrowing, where g++ is not
 	EXTRA_FLAGS=-Wno-c++11-narrowing $(MAKE) -C src/vdp
 else
 	$(MAKE) -C src/vdp

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    println!("cargo:rustc-link-search=native=/opt/homebrew/lib");
+    system_deps::Config::new().probe().unwrap();
     if std::env::var("FORCE").is_err() {
         eprintln!("Don't invoke `cargo build` directly. Try using 'make' to build fab-agon-emulator.");
         eprintln!("If you really know what you're doing, try again with `FORCE=1 cargo build`");


### PR DESCRIPTION
So, thanks for taking the appropriate bits from my last.  Here's another set.  PLATFORM is unset on mac, so I've created a variable COMPILER which will get set to g++ or clang depending on $(CXX) --version.  It will then set your no-narrowing warnings flag on clang.  I think that's the right move - you could be running clang on a different platform - it's getting popular these days.  Also, I found a better fix (not hardcoding a path) for the SDL2 location problem.  My build worked once I replaced -lpthread with -pthread (as another user has already mentioned) on the test_main build.  I haven't included that change.
I've also created some Dockerfiles which I used to test these changes on Alpine and debian buster.  Happy to contribute those.