### PR TITLE
Fix a build error on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/tomm/fab-agon-emulator"
 
 [build-dependencies]
 # system-deps does platform searches for dependencies and sets -L and -l appropriately
-system-deps = "2.0"
+system-deps = "6.2.0"
 
-[package.metadata.system-deps]
+[package.metadata.system-deps.'cfg(not(target_os = "windows"))']
 sdl2 = "0.35.2"
 
 [dependencies]


### PR DESCRIPTION
The recent introduction of system-deps broke the build on Windows, apparently because system-deps uses pkg-config internally, and Windows does not have it. The quick and dirty fix is make system-deps to not run on Windows targets (Linux and MacOS supposedly have pkg-config).

Also bumped to a newer version of system-deps.