### PR TITLE
Add os detection to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,21 @@
+ifeq ($(OS),Windows_NT)
+	OS_DETECTED := Windows
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		OS_DETECTED := Linux
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		OS_DETECTED := Darwin
+	endif
+endif
+
 all: check vdp cargo
 
 COMPILER := $(filter g++ clang,$(shell $(CXX) --version))
 
 check:
-ifeq ($(OS),Windows_NT)
+ifeq ($(OS_DETECTED),Windows)
 	@if not exist ./src/vdp/userspace-vdp-gl/README.md ( echo Error: no source tree in ./src/vdp/userspace-vdp. && echo Maybe you forgot to run: git submodule update --init && exit /b 1 )
 else
 	@if [ ! -f ./src/vdp/userspace-vdp-gl/README.md ]; then echo "Error: no source tree in ./src/vdp/userspace-vdp."; echo "Maybe you forgot to run: git submodule update --init"; echo; exit 1; fi
@@ -16,12 +28,17 @@ ifeq ($(COMPILER),clang)
 else
 	$(MAKE) -C src/vdp
 endif
+
+ifeq ($(OS_DETECTED),Windows)
+	copy src\vdp\*.so firmware
+else
 	cp src/vdp/*.so firmware/
+endif
 
 cargo:
-ifeq ($(OS),Windows_NT)
+ifeq ($(OS_DETECTED),Windows)
 	set FORCE=1 && cargo build -r
-	cp ./target/release/fab-agon-emulator.exe .
+	copy target\release\fab-agon-emulator.exe .
 else
 	FORCE=1 cargo build -r
 	cp ./target/release/fab-agon-emulator .

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Read about other command-line options with:
 * add C:\Program Files (x86)\GnuWin32\bin to path
 * Install mingw64 from https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-16.0.6-11.0.1-ucrt-r2/winlibs-x86_64-mcf-seh-gcc-13.2.0-llvm-16.0.6-mingw-w64ucrt-11.0.1-r2.zip
 * extract to C:\mingw64 and add C:\mingw64\bin to path
-* Install CoreUtils for Windows from https://sourceforge.net/projects/gnuwin32/files/coreutils/5.3.0/coreutils-5.3.0-bin.zip
-* extract to C:\coreutils (or other location of your choice) and add C:\coreutils\bin to path
 * get SDL2 from https://github.com/libsdl-org/SDL/releases/download/release-2.28.3/SDL2-devel-2.28.3-mingw.zip
 * extract to C:\Users\<user>\.rustup\toolchains\stable-x86_64-pc-windows-gnu
 * copy SDL2.dll to the root of the project


### PR DESCRIPTION
With a proper OS detection in makefile it is possible to switch tools in the buildprocess and no longer need coreutils on windows.