### PR TITLE
Add dpad support for both game ports.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -335,6 +335,9 @@ pub fn main() -> Result<(), pico_args::Error> {
                             (*vdp_interface.sendHostMouseEventToFabgl)(&packet[0] as *const u8);
                         }
                     }
+                    Event::JoyHatMotion { which, hat_idx, state, ..} => {
+                        joypad::on_hat_motion(&mut gpios.lock().unwrap(), which, hat_idx, state);
+                    }
                     Event::JoyButtonUp { which, button_idx, .. } => {
                         joypad::on_button(&mut gpios.lock().unwrap(), which, button_idx, false);
                     }


### PR DESCRIPTION
This adds support for DPAD controls. Ive tested it on xbox one controllers on windows. It does support multiple controllers and every controller after the first gets mapped as player 2.