### PR TITLE
Update build process to support macos fat binary.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,17 @@ license.workspace = true
 system-deps = "6.2.0"
 
 [package.metadata.system-deps.'cfg(not(target_os = "windows"))']
-sdl2 = "0.35.2"
+sdl2 = "0.36.0"
 
 [dependencies]
-sdl2 = "0.35.2"
+sdl2 = "0.36.0"
 pico-args = "0.5.0"
 agon-cpu-emulator = { workspace = true }
 agon-light-emulator-debugger = { path = "agon-light-emulator-debugger" }
 libloading = "0.8.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+sdl2 = { version = "0.36.0", features = ["bundled"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 raw_tty = "0.1.0"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: check vdp cargo
 
 COMPILER := $(filter g++ clang,$(shell $(CXX) --version))
+UNAME_S := $(shell uname)
 
 check:
 ifeq ($(OS),Windows_NT)
@@ -9,12 +10,21 @@ else
 	@if [ ! -f ./src/vdp/userspace-vdp-gl/README.md ]; then echo "Error: no source tree in ./src/vdp/userspace-vdp."; echo "Maybe you forgot to run: git submodule update --init"; echo; exit 1; fi
 endif
 
+
 vdp:
-ifeq ($(COMPILER),clang)
-	# clang is strict about narrowing, where g++ is not
-	EXTRA_FLAGS=-Wno-c++11-narrowing $(MAKE) -C src/vdp
+ifneq ($(OS), Windows_NT)
+ifeq ($(UNAME_S),Darwin)
+	EXTRA_FLAGS="-Wno-c++11-narrowing -arch x86_64" SUFFIX=.x86_64 $(MAKE) -C src/vdp
+	EXTRA_FLAGS="-Wno-c++11-narrowing -arch arm64" SUFFIX=.arm64 $(MAKE) -C src/vdp
+	$(foreach file, $(wildcard src/vdp/*.x86_64.so), lipo -create -output src/vdp/$(notdir $(file:.x86_64.so=.so)) $(file) src/vdp/$(notdir $(file:.x86_64.so=.arm64.so));)
+endif
 else
-	$(MAKE) -C src/vdp
+	ifeq ($(COMPILER),clang)
+		# clang is strict about narrowing, where g++ is not
+		EXTRA_FLAGS=-Wno-c++11-narrowing $(MAKE) -C src/vdp
+	else
+		$(MAKE) -C src/vdp
+	endif
 endif
 	cp src/vdp/*.so firmware/
 
@@ -22,6 +32,10 @@ cargo:
 ifeq ($(OS),Windows_NT)
 	set FORCE=1 && cargo build -r
 	cp ./target/release/fab-agon-emulator.exe .
+else ifeq ($(UNAME_S),Darwin)
+	FORCE=1 cargo build -r --target=x86_64-apple-darwin
+	FORCE=1 cargo build -r --target=aarch64-apple-darwin
+	lipo -create -output ./fab-agon-emulator ./target/x86_64-apple-darwin/release/fab-agon-emulator ./target/aarch64-apple-darwin/release/fab-agon-emulator
 else
 	FORCE=1 cargo build -r
 	cp ./target/release/fab-agon-emulator .

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" && std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "macos" {
         system_deps::Config::new().probe().unwrap();
     }
     if std::env::var("FORCE").is_err() {

--- a/src/vdp/Makefile
+++ b/src/vdp/Makefile
@@ -4,27 +4,27 @@ OPTIONS =
 
 SRCS = rust_glue.cpp
 
-OBJS = $(SRCS:.cpp=.o)
+OBJS = $(SRCS:.cpp=$(SUFFIX).o)
 
-.cpp.o:
+%$(SUFFIX).o: %.cpp
 	$(CXX) $(CFLAGS) $(OPTIONS) -c $< -o $@
 
-all: userspace-vdp-gl/vdp_gl.a vdp_console8.so vdp_quark103.so vdp_quark.so test_main
+all: userspace-vdp-gl/vdp_gl$(SUFFIX).a vdp_console8$(SUFFIX).so vdp_quark103$(SUFFIX).so vdp_quark$(SUFFIX).so
 
-userspace-vdp-gl/vdp_gl.a:
+userspace-vdp-gl/vdp_gl$(SUFFIX).a:
 	$(MAKE) -C userspace-vdp-gl/src
 
-test_main: $(OBJS) userspace-vdp-gl/vdp_gl.a vdp-1.03.o test_main.o
-	$(CXX) $(OBJS) -pthread test_main.o vdp-1.03.o userspace-vdp-gl/src/vdp-gl.a -o test_main
+test_main$(SUFFIX): $(OBJS) userspace-vdp-gl/vdp_gl$(SUFFIX).a vdp-1.03$(SUFFIX).o test_main$(SUFFIX).o
+	$(CXX) $(CFLAGS) $(OBJS) -pthread test_main$(SUFFIX).o vdp-1.03$(SUFFIX).o userspace-vdp-gl/src/vdp-gl$(SUFFIX).a -o test_main$(SUFFIX)
 
-vdp_console8.so: $(OBJS) userspace-vdp-gl/vdp_gl.a vdp-console8.o
-	$(CXX) -shared $(OBJS) vdp-console8.o userspace-vdp-gl/src/vdp-gl.a -o vdp_console8.so
+vdp_console8$(SUFFIX).so: $(OBJS) userspace-vdp-gl/vdp_gl$(SUFFIX).a vdp-console8$(SUFFIX).o
+	$(CXX) $(CFLAGS) -shared $(OBJS) vdp-console8$(SUFFIX).o userspace-vdp-gl/src/vdp-gl$(SUFFIX).a -o vdp_console8$(SUFFIX).so
 
-vdp_quark103.so: $(OBJS) userspace-vdp-gl/vdp_gl.a vdp-1.03.o
-	$(CXX) -shared $(OBJS) vdp-1.03.o userspace-vdp-gl/src/vdp-gl.a -o vdp_quark103.so
+vdp_quark103$(SUFFIX).so: $(OBJS) userspace-vdp-gl/vdp_gl$(SUFFIX).a vdp-1.03$(SUFFIX).o
+	$(CXX) $(CFLAGS) -shared $(OBJS) vdp-1.03$(SUFFIX).o userspace-vdp-gl/src/vdp-gl$(SUFFIX).a -o vdp_quark103$(SUFFIX).so
 
-vdp_quark.so: $(OBJS) userspace-vdp-gl/vdp_gl.a vdp-quark.o
-	$(CXX) -shared $(OBJS) vdp-quark.o userspace-vdp-gl/src/vdp-gl.a -o vdp_quark.so
+vdp_quark$(SUFFIX).so: $(OBJS) userspace-vdp-gl/vdp_gl$(SUFFIX).a vdp-quark$(SUFFIX).o
+	$(CXX) $(CFLAGS) -shared $(OBJS) vdp-quark$(SUFFIX).o userspace-vdp-gl/src/vdp-gl$(SUFFIX).a -o vdp_quark$(SUFFIX).so
 
 clean:
 	-rm *.o


### PR DESCRIPTION
 * Allow build to run with a suffix so that x86_64 and arm64 can be built as separate passes and then combined using lipo. Might not be the most efficient, but it's a start.