### PR TITLE
Switch Windows build environment to MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,7 @@ COMPILER := $(filter g++ clang,$(shell $(CXX) --version))
 UNAME_S := $(shell uname)
 
 check:
-ifeq ($(OS),Windows_NT)
-	@if not exist ./src/vdp/userspace-vdp-gl/README.md ( echo Error: no source tree in ./src/vdp/userspace-vdp. && echo Maybe you forgot to run: git submodule update --init && exit /b 1 )
-else
 	@if [ ! -f ./src/vdp/userspace-vdp-gl/README.md ]; then echo "Error: no source tree in ./src/vdp/userspace-vdp."; echo "Maybe you forgot to run: git submodule update --init"; echo; exit 1; fi
-endif
 
 
 vdp:

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -35,9 +35,11 @@ sudo make install
 * Download the `msys-init.sh` script from this repo (making sure to download the raw version instead of the html from github).
 * Start MSYS2 in UCRT64 mode (there is a separate icon for each mode in the start menu, but you can just search for UCRT64).
 * Run the init script with bash: `bash msys-init.sh`. It will update MSYS2, and then install all the build dependencies for the emulator.
-* MSYS2 will probably want to restart after it installs the updates. If so, then run `msys-init.sh` again afterwards.
-* Run `cd fab-agon-emulator` and then `make` in the root of the project.
-* Run `./fab-agon-emulator.exe` in the root of the project.
+* MSYS2 will probably restart after it installs the updates. If so, then run `bash msys-init.sh` again afterwards.
+* Change to the project root: `cd fab-agon-emulator`
+* **First time only** initialization: `git submodule update --init`
+* Build the project: `make`
+* Run the executable: `./fab-agon-emulator.exe`
 
 ## Compiling for Mac
 

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -29,20 +29,12 @@ sudo make install
 
 ## Compiling for Windows
 
-### To build on Windows (mingw)
+### To build on Windows (MSYS2)
 
-* Install rustup from https://rustup.rs/
-* rustup toolchain install stable-x86_64-pc-windows-gnu
-* rustup default stable-x86_64-pc-windows-gnu
-* Install make winget install GnuWin32.Make
-* add C:\Program Files (x86)\GnuWin32\bin to path
-* Install mingw64 from https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-16.0.6-11.0.1-ucrt-r2/winlibs-x86_64-mcf-seh-gcc-13.2.0-llvm-16.0.6-mingw-w64ucrt-11.0.1-r2.zip
-* extract to C:\mingw64 and add C:\mingw64\bin to path
-* Install CoreUtils for Windows from https://sourceforge.net/projects/gnuwin32/files/coreutils/5.3.0/coreutils-5.3.0-bin.zip
-* extract to C:\coreutils (or other location of your choice) and add C:\coreutils\bin to path
-* get SDL2 from https://github.com/libsdl-org/SDL/releases/download/release-2.28.3/SDL2-devel-2.28.3-mingw.zip
-* extract to C:\Users\<user>\.rustup\toolchains\stable-x86_64-pc-windows-gnu
-* copy SDL2.dll to the root of the project
+* Download [MSYS2](https://www.msys2.org/) and follow the instructions to install it.
+* Download the `msys-init.sh` script from this repo (making sure to download the raw version instead of the html from github).
+* Start MSYS2 in UCRT64 mode (there is a separate icon for each mode in the start menu, but you can just search for UCRT64).
+* Run the init script with bash: `bash msys-init.sh`.  It will update MSYS2 (probably requiring a restart), and then install all the build dependencies for the emulator.
 * run `make` in the root of the project
 * run `fab-agon-emulator.exe` in the root of the project
 

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -34,9 +34,10 @@ sudo make install
 * Download [MSYS2](https://www.msys2.org/) and follow the instructions to install it.
 * Download the `msys-init.sh` script from this repo (making sure to download the raw version instead of the html from github).
 * Start MSYS2 in UCRT64 mode (there is a separate icon for each mode in the start menu, but you can just search for UCRT64).
-* Run the init script with bash: `bash msys-init.sh`.  It will update MSYS2 (probably requiring a restart), and then install all the build dependencies for the emulator.
-* run `make` in the root of the project
-* run `fab-agon-emulator.exe` in the root of the project
+* Run the init script with bash: `bash msys-init.sh`. It will update MSYS2, and then install all the build dependencies for the emulator.
+* MSYS2 will probably want to restart after it installs the updates. If so, then run `msys-init.sh` again afterwards.
+* Run `cd fab-agon-emulator` and then `make` in the root of the project.
+* Run `./fab-agon-emulator.exe` in the root of the project.
 
 ## Compiling for Mac
 

--- a/msys-init.sh
+++ b/msys-init.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-echo "MSYS2 may ask to restart after this update. If so, rerun this script afterwards."
+REPO=${REPO:-https://github.com/tomm/fab-agon-emulator.git}
+set -euxo pipefail # bash strict mode: https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425
+
+echo "⚠️ MSYS2 may ask to restart after this update. If so, rerun this script afterwards."
 pacman --noconfirm -Syu
-echo "Installing build dependencies for fab-agon-emulator..."
+echo "👌 Installing build dependencies for fab-agon-emulator..."
 pacman --noconfirm -S \
     vim \
     git \
@@ -9,4 +12,12 @@ pacman --noconfirm -S \
     ucrt64/mingw-w64-ucrt-x86_64-SDL2 \
     ucrt64/mingw-w64-ucrt-x86_64-gcc \
     ucrt64/mingw-w64-ucrt-x86_64-rust
-git clone https://github.com/tomm/fab-agon-emulator.git
+echo "👋 Cloning ${REPO}"
+git clone 
+cd fab-agon-emulator
+echo "
+⭐ MSYS2 initialization complete
+⭐ Build dependencies for fab-egon-emulator installed
+⭐ github repo ${REPO} cloned and submodules initialized
+🪄 Enjoy!
+"

--- a/msys-init.sh
+++ b/msys-init.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 REPO=${REPO:-https://github.com/tomm/fab-agon-emulator.git}
-set -euxo pipefail # bash strict mode: https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425
+set -euo pipefail # bash strict mode: https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425
 
-echo "⚠️ MSYS2 may ask to restart after this update. If so, rerun this script afterwards."
+echo "
+⚠️ MSYS2 may ask to restart after this update. If so, rerun this script afterwards.
+"
 pacman --noconfirm -Syu
-echo "👌 Installing build dependencies for fab-agon-emulator..."
+
+echo "
+⚙️ Installing build dependencies for fab-agon-emulator...
+"
 pacman --noconfirm -S \
     vim \
     git \
@@ -12,12 +17,24 @@ pacman --noconfirm -S \
     ucrt64/mingw-w64-ucrt-x86_64-SDL2 \
     ucrt64/mingw-w64-ucrt-x86_64-gcc \
     ucrt64/mingw-w64-ucrt-x86_64-rust
-echo "👋 Cloning ${REPO}"
-git clone 
-cd fab-agon-emulator
+
 echo "
 ⭐ MSYS2 initialization complete
 ⭐ Build dependencies for fab-egon-emulator installed
-⭐ github repo ${REPO} cloned and submodules initialized
-🪄 Enjoy!
+
+👋 Cloning ${REPO}...
+"
+git clone "${REPO}"
+
+echo "
+⭐ github repo ${REPO} cloned 
+
+🤝 Please run the following commands:
+
+cd fab-agon-emulator
+git submodule update --init
+make
+./fab-agon-emulator.exe
+
+🎉 Enjoy!
 "

--- a/msys-init.sh
+++ b/msys-init.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+echo "MSYS2 may ask to restart after this update. If so, rerun this script afterwards."
+pacman --noconfirm -Syu
+echo "Installing build dependencies for fab-agon-emulator..."
+pacman --noconfirm -S \
+    vim \
+    git \
+    make \
+    ucrt64/mingw-w64-ucrt-x86_64-SDL2 \
+    ucrt64/mingw-w64-ucrt-x86_64-gcc \
+    ucrt64/mingw-w64-ucrt-x86_64-rust
+git clone https://github.com/tomm/fab-agon-emulator.git


### PR DESCRIPTION
Current build instructions for Windows say to use an ad-hoc collection of tools that requires a lot of manual installation.  MSYS2 provides a Linux-like build environment and packages for all the dependencies required to build fab-agon-emulator.  Besides the convenience factor, the GnuWin32 packages have been removed from winget. The GNU Make packages from GnuWin32 is over 18 years old so it is better to use a more modern version.

I have made a `msys-init.sh` script which will automatically update MSYS2, install the dependencies and clone the git repo for the user.  All the user has to do is install MSYS2 through the graphical installer and run the script. I also updated the build instructions and Makefile for the new environment. I needed to remove the check for Windows_NT from the makefile, because GNU Make detects MSYS2 as Windows_NT but MSYS2 has bash, and so the conditional check to use batch files would cause the build to fail.